### PR TITLE
Create README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
+![OneSignal](https://github.com/OneSignal/.github/blob/439e36ade56b001643ff3b07eeaf95b20129f3e6/assets/onesignal-banner.png)
+
+<div align="center">
+  <a href="https://documentation.onesignal.com/docs/onboarding-with-onesignal" target="_blank">Quickstart</a>
+  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <a href="https://onesignal.com/" target="_blank">Website</a>
+  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <a href="https://documentation.onesignal.com/docs" target="_blank">Docs</a>
+  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <a href="https://github.com/OneSignalDevelopers" target="_blank">Examples</a>
+  <br />
+  <hr />
+</div>
+
 # OneSignal iOS Sample


### PR DESCRIPTION
Adds a readme to guide to serve as an example of integrating OneSignal into an iOS app using SwiftUI.

[📝 Rendered markdown](https://github.com/OneSignalDevelopers/onesignal-ios-sample/blob/e7274500fa9437ca3034b7d9fa238e91730a389a/README.md)
